### PR TITLE
docs: add dependency installation step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Clone this repository with Git:
 ```sh
 git clone https://github.com/zoedsoupe/exlings
 cd exlings
+mix deps.get
 ```
 
 Now you're ready to start! Run the following to begin:


### PR DESCRIPTION
## Problem

When starting afresh, user gets this error if strictly following the README:
```bash
mix exlings
```
```console
Unchecked dependencies for environment dev:
* credo (Hex package)
  the dependency is not available, run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
```

## Solution

Add the missing `mix deps.get` command to the setup instructions to ensure users install required dependencies after cloning the repository.

## Rationale

I've been learning elixir for about a week now, this is pretty easy to figure out (this has come out at a great time for me, so thanks!), but it is required so better to have it written down here I thought; plus, I'm after some "eternal exlings contributor glory"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installation guide updated to include an explicit step to fetch project dependencies after entering the repository. This clarifies initial setup, reduces installation errors for new users, and ensures required libraries are installed as part of the first-time setup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->